### PR TITLE
[feature] connect products(main, explore) & add notfound page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import DetailPage from "./pages/DetailPage";
 import ExplorePage from "./pages/ExplorePage";
 import MyPage from "./pages/MyPage";
 import Layout from "./components/Layout/Layout";
+import NotFound from "./pages/NotFound";
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
         <Route path="/explore" element={<ExplorePage />} />
         <Route path="/mypage" element={<Navigate replace to='/mypage/settings' />} />
         <Route path="/mypage/*" element={<MyPage /> } />
+        <Route path="*" element={<NotFound /> } />
       </Routes>
     </Layout>
   );

--- a/src/components/Post/MainPost.js
+++ b/src/components/Post/MainPost.js
@@ -13,10 +13,10 @@ const ImageSize = styled.img`
 `;
 
 const MainPost = props => {
-  const { type, name, company, price } = props
+  const { type, name, company, price, id } = props
 
   return (
-    <Link to={"/detail"}>
+    <Link to={`/detail/product/${id}`}>
         <Box sx={{ padding: "12px" }}>
             <Box sx={{
                 padding: "12px", 

--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -16,7 +16,7 @@ const ImageSize = styled.img`
 const Post = forwardRef(({ post }, ref) => {
 
     const postBody = (
-        <Link to={`/detail/${post.id}`}>
+        <Link to={`/detail/product/${post.id}`}>
             <Box sx={{ 
                     display: "flex",
 

--- a/src/components/Product/DetailMain.jsx
+++ b/src/components/Product/DetailMain.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
-import PriceCard from "./PriceCard";
+// import PriceCard from "./PriceCard";
 import NameCard from "./NameCard";
 import DetailImage from "./DetailImage";
 

--- a/src/components/Product/NameCard.jsx
+++ b/src/components/Product/NameCard.jsx
@@ -10,14 +10,12 @@ import { useParams } from "react-router-dom";
 export default function NameCard() {
   const [data, setData] = useState(null);
   const param = useParams();
-  console.log(param);
-  console.log(getProductDetail(1));
 
   useEffect(() => {
     getProductDetail(param.productId).then((data) => {
       setData(data);
     });
-  }, []);
+  }, [param]);
 
   if (!data) return <>Loading...</>;
   return (

--- a/src/components/Slick/Slick.jsx
+++ b/src/components/Slick/Slick.jsx
@@ -111,7 +111,7 @@ class ProductSlider extends Component {
         {this.state.slides.map((slide, index) => {
           return (
             <div key={index}>
-              <MainPost price={slide.price} type={slide.soolType} name={slide.name} company={slide.company} />
+              <MainPost id={slide.id} price={slide.price} type={slide.soolType} name={slide.name} company={slide.company} />
             </div>
           );
         })}

--- a/src/components/common/ScrollToTop.jsx
+++ b/src/components/common/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+
+    return null;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,16 @@ import './index.css';
 import App from './App';
 import CssBaseline from '@mui/material/CssBaseline';
 import { BrowserRouter as Router } from "react-router-dom";
+import ScrollToTop from './components/common/ScrollToTop';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <CssBaseline />
-    <Router><App /></Router>
+    <Router>
+      <ScrollToTop />
+      <App />
+    </Router>
   </React.StrictMode>
 );
 

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDissatisfied';
+
+const NotFoundPage = styled.div`
+    width: 100%;
+    height: 500px;
+    text-align: center;
+    font-weight: bold;
+    font-size: 30px;
+    padding-top: 100px;
+`
+
+const NotFound = () => {
+    return (
+        <NotFoundPage>
+            <SentimentVeryDissatisfiedIcon fontSize="large" />
+            <br />
+            Page Not Found.
+        </NotFoundPage>
+    )
+}
+
+export default NotFound;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7858,7 +7858,7 @@ react-scripts@5.0.1:
 
 react-slick@^0.29.0:
   version "0.29.0"
-  resolved "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz"
+  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.29.0.tgz#0bed5ea42bf75a23d40c0259b828ed27627b51bb"
   integrity sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==
   dependencies:
     classnames "^2.2.5"


### PR DESCRIPTION
## ✨ 작업 내용
- #63 
- 각 상품별 페이지 연결
- not found 페이지 추가

## 🌈 상세 설명
- 메인페이지와 상품 링크
- 탐색 페이지와 상품 링크
- 잘못된 url 일 때, not found 페이지로 연결
- 라우터로 이동 시 전 스크롤 위치가 다음 페이지까지 영향을 미쳐서 ScrollToTop 컴포넌트를 추가 했습니다.
